### PR TITLE
fix: recompute replacement hashmap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,7 +954,7 @@ checksum = "a67300977d3dc3f8034dae89778f502b6ba20b269527b3223ba59c0cf393bb8a"
 
 [[package]]
 name = "zeditor"
-version = "0.1.6-d"
+version = "0.1.6-e"
 dependencies = [
  "blake3",
  "cursive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeditor"
-version = "0.1.6-d"
+version = "0.1.6-e"
 edition = "2021"
 
 [dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use cursive::Cursive;
 use std::sync::{Arc, Mutex};
 use zeditor::db::Db;
 use zeditor::msg::Msg;
-use zeditor::replace::{HitsReplaced, ReplaceHits};
+use zeditor::replace::{HitsReplaced, ReplaceCommand};
 use zeditor::screens::ZeditorScreens;
 use zeditor::search::{Hit, SearchCommand};
 use zeditor::skip::SkipRepo;
@@ -23,7 +23,7 @@ async fn main() {
 
     tokio::spawn(async move { zeditor::search::run(db, files_searched_s, search_files_r).await });
 
-    let (replace_hits_s, replace_hits_r) = unbounded::<Msg<ReplaceHits>>();
+    let (replace_hits_s, replace_hits_r) = unbounded::<Msg<ReplaceCommand>>();
     let (hits_replaced_s, hits_replaced_r) = unbounded::<HitsReplaced>();
 
     tokio::spawn(async move { zeditor::replace::run(db2, hits_replaced_s, replace_hits_r).await });

--- a/src/quit.rs
+++ b/src/quit.rs
@@ -1,9 +1,9 @@
 use cursive::{reexports::crossbeam_channel::Sender, views::Button, Cursive};
 
-use crate::{msg::Msg, replace::ReplaceHits, search::SearchCommand};
+use crate::{msg::Msg, replace::ReplaceCommand, search::SearchCommand};
 
 pub fn quit_button(
-    replace: Sender<Msg<ReplaceHits>>,
+    replace: Sender<Msg<ReplaceCommand>>,
     search: Sender<Msg<SearchCommand>>,
 ) -> Button {
     Button::new("Quit", move |s| {


### PR DESCRIPTION
updates the replacement thread's local search->replace hashmap whenever there's a new entry given via the UI